### PR TITLE
feat: enable homebrew support in nix

### DIFF
--- a/nix/darwin-configuration.nix
+++ b/nix/darwin-configuration.nix
@@ -1,0 +1,32 @@
+{ config, ... }:
+{
+
+  # Enable homebrew
+  # homebrew = {
+  #   enable = true;
+  #   onActivation.cleanup = "zap";
+  #   onActivation.autoUpdate = true;
+  #   onActivation.upgrade = true;
+  # };
+
+  ids.gids.nixbld = 350;
+
+  # System-level user configurations
+  users.users."skyler.lemay" = {
+    name = "skyler.lemay";
+    home = "/Users/skyler.lemay";
+  };
+
+  # Enable experimental features
+  nix.settings.experimental-features = "nix-command flakes";
+
+  # Set Git commit hash for darwin-rebuild
+  system.configurationRevision = config.rev or config.dirtyRev or null;
+
+  # Used for backwards compatibility, please read the changelog before changing.
+  # $ darwin-rebuild changelog
+  system.stateVersion = 4;
+
+  # The platform the configuration will be used on.
+  nixpkgs.hostPlatform = "aarch64-darwin";
+}

--- a/nix/darwin-configuration.nix
+++ b/nix/darwin-configuration.nix
@@ -1,15 +1,12 @@
 { config, ... }:
 {
 
-  # Enable homebrew
-  # homebrew = {
-  #   enable = true;
-  #   onActivation.cleanup = "zap";
-  #   onActivation.autoUpdate = true;
-  #   onActivation.upgrade = true;
-  # };
+  imports = [
+    ./module/homebrew.nix
+  ];
 
   ids.gids.nixbld = 350;
+  system.primaryUser = "skyler.lemay";
 
   # System-level user configurations
   users.users."skyler.lemay" = {

--- a/nix/flake.nix
+++ b/nix/flake.nix
@@ -17,21 +17,23 @@
   };
 
   outputs =
-    { nixpkgs, home-manager, ... }:
+    { home-manager, darwin, ... }:
     let
       system = "aarch64-darwin";
-      pkgs = nixpkgs.legacyPackages.${system};
     in
     {
-      homeConfigurations."skyler.lemay" = home-manager.lib.homeManagerConfiguration {
-        inherit pkgs;
-
-        # Specify your home configuration modules here, for example,
-        # the path to your home.nix.
-        modules = [ ./home.nix ];
-
-        # Optionally use extraSpecialArgs
-        # to pass through arguments to home.nix
+      darwinConfigurations."entorenee" = darwin.lib.darwinSystem {
+        inherit system;
+        modules = [
+          ./darwin-configuration.nix
+          home-manager.darwinModules.home-manager
+          {
+            home-manager.useGlobalPkgs = false;
+            home-manager.useUserPackages = true;
+            # TODO: This will need to be dynamic for mnultiple profiles in the future
+            home-manager.users."skyler.lemay" = import ./home.nix;
+          }
+        ];
       };
     };
 }

--- a/nix/module/home-manager.nix
+++ b/nix/module/home-manager.nix
@@ -8,7 +8,6 @@
     ./gh
     ./git
     ./gnupg
-    ./karabiner
     ./nvim
     ./pkgs.nix
     ./starship

--- a/nix/module/homebrew.nix
+++ b/nix/module/homebrew.nix
@@ -1,0 +1,31 @@
+{ ... }:
+{
+  imports = [
+    ./karabiner
+  ];
+
+  homebrew = {
+    enable = true;
+    global.autoUpdate = false;
+
+    brews = [
+      "node"
+      "nvm"
+      "pinentry"
+      "pinentry-mac"
+      "Z"
+    ];
+
+    casks = [
+      "docker"
+      "elgato-control-center"
+      "iterm2"
+      "karabiner-elements"
+      "obsidian"
+      "rectangle"
+      "vlc"
+      "yubico-authenticator"
+      "zoom"
+    ];
+  };
+}

--- a/nix/module/karabiner/default.nix
+++ b/nix/module/karabiner/default.nix
@@ -1,13 +1,10 @@
+{ ... }:
 {
-  pkgs,
-  ...
-}:
-{
-  ## TODO: determine if this should be moved back to Homebrew for global application install
-  home.packages =
-    with pkgs;
-    [
-      karabiner-elements
-    ];
-  xdg.configFile."karabiner".source = ./config;
+  homebrew.casks = [
+    "karabiner-elements"
+  ];
+
+  home-manager.users."skyler.lemay" = { ... }: {
+    xdg.configFile."karabiner".source = ./config;
+  };
 }

--- a/nix/module/pkgs.nix
+++ b/nix/module/pkgs.nix
@@ -17,23 +17,13 @@
       git-lfs
       git-up
       htop
-      # iterm2
       jq
-      # karabiner-elements
-      # nerd-fonts.sauce-code-pro
-      # obsidian
-      # pinentry-tty
-      # pinentry_mac
       # postgresql
       # python313
-      rectangle
       ripgrep
       tmuxinator
       tree
-      # vlc
-      vlc-bin-universal
       wget
       yubikey-manager
-      zoom-us
     ];
 }

--- a/scripts/homebrew-setup.sh
+++ b/scripts/homebrew-setup.sh
@@ -15,12 +15,7 @@ brew update
 
 BASE_PACKAGES=(
   hub
-  node
-  nvm
-  pinentry
   rcm
-  tmux
-  Z
 )
 
 PERSONAL_PACKAGES=(
@@ -45,10 +40,7 @@ echo "Installing packages..."
 brew install ${PACKAGES[@]}
 
 BASE_CASKS=(
-  docker
-  elgato-control-center Stay in Brew?
   firefox # Home Manager
-  yubico-authenticator # Stay in Brew?
 )
 
 PERSONAL_CASKS=(


### PR DESCRIPTION
## Purpose

**As an engineer**
**I want to** shift my configuration to utilize Nix Darwin
**So that** I can manage homebrew with Nix.

**Issue link (if applicable):** #12

## Implementation Notes

This shifts the project to use Nix Darwin which is necessary since Homebrew is only applicable to Mac computers. This does not fully migrate away from the old approach as handling the branching logic of personal vs work packages is still to be implemented.